### PR TITLE
Form key on all start events

### DIFF
--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/property/tabs/builder/StartEventPropertiesBuilder.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/property/tabs/builder/StartEventPropertiesBuilder.java
@@ -23,9 +23,7 @@ public class StartEventPropertiesBuilder extends AbstractPropertiesBuilder<Start
 	public void create() {
 		List<EventDefinition> eventDefinitions = ModelUtil.getEventDefinitions(bo);
 		
-		if (!hasDefinitions(eventDefinitions)) {
-			PropertyUtil.createText(section, parent, "Form Key", ModelPackage.eINSTANCE.getDocumentRoot_FormKey(), bo);
-		}
+		PropertyUtil.createText(section, parent, "Form Key", ModelPackage.eINSTANCE.getDocumentRoot_FormKey(), bo);
 		
 		if (isContainedInEventSubProcess(bo)) {
 			PropertyUtil.createCheckbox(section, parent, "Interrupting", Bpmn2Package.eINSTANCE.getStartEvent_IsInterrupting(), bo);


### PR DESCRIPTION
Restricting the form key to only None Start Events is too restictive for two reasons:
1. A start form might very well send a Message or Signal to the proces engine to start a process instance.
2. The camunda BPMN Framework recommends to model human flows and technical flows of an operational process model as a collaboration. In most cases this requires the technical process to be started by a Message (see also our twitter and invoice examples).

![Invoice Example Process](https://github.com/camunda/camunda-bpm-examples/raw/master/invoice-en/src/main/resources/camunda-invoice-en-collaboration.png)

The restriction could make sense for Timer Start Events, because these are only executed by the engine. However, I'd rather prefer to keep it open for now, because the engine doesn't require this restriction.
