### PR TITLE
feat(diagram-handling): open non-workspace files

### DIFF
--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/diagram/editor/Bpmn2DiagramEditorInput.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/diagram/editor/Bpmn2DiagramEditorInput.java
@@ -13,26 +13,29 @@
 package org.camunda.bpm.modeler.ui.diagram.editor;
 
 import org.camunda.bpm.modeler.core.utils.ModelUtil.Bpmn2DiagramType;
+import org.camunda.bpm.modeler.ui.wizards.FileService;
 import org.eclipse.bpmn2.di.BPMNDiagram;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.graphiti.ui.editor.DiagramEditorInput;
+import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IMemento;
-import org.eclipse.ui.part.FileEditorInput;
 
 public final class Bpmn2DiagramEditorInput extends DiagramEditorInput {
 
-	private final TransactionalEditingDomain domain;
 	private Bpmn2DiagramType initialDiagramType = Bpmn2DiagramType.NONE;
+
 	private String targetNamespace;
 	private BPMNDiagram bpmnDiagram;
 	private URI modelUri;
 	
 	public Bpmn2DiagramEditorInput(URI modelUri, URI diagramUri, TransactionalEditingDomain domain, String providerId) {
-		// means : DiagramEditorInput.uri = diagramUri
 		super(diagramUri, providerId);
-		this.domain = domain;
+	
 		this.modelUri = modelUri;
 	}
 	
@@ -52,7 +55,7 @@ public final class Bpmn2DiagramEditorInput extends DiagramEditorInput {
 		this.targetNamespace = targetNamespace;
 	}
 
-	public URI  getModelUri() {
+	public URI getModelUri() {
 		return modelUri;
 	}
 	
@@ -65,7 +68,7 @@ public final class Bpmn2DiagramEditorInput extends DiagramEditorInput {
 	}
 	
 	public String getToolTipText() {
-		return modelUri.toPlatformString(true);
+		return modelUri.isPlatformResource() ? modelUri.toPlatformString(true) : modelUri.toFileString();
 	}
 	
 	public String getName() {
@@ -79,36 +82,60 @@ public final class Bpmn2DiagramEditorInput extends DiagramEditorInput {
 		else
 			super.updateUri(diagramFileUri);
 	}
-	
+
 	@Override
 	public boolean equals(Object obj) {
-		boolean superEquals = super.equals(obj);
-		if (superEquals) {
+		if (super.equals(obj)) {
 			return true;
 		}
 
-		// Eclipse makes FileEditorInputs for files to be opened. Here we check if the file is actually the same
-		// as the DiagramEditorInput uses. This is for preventing opening new editors for the same file.
-		if (obj instanceof FileEditorInput) {
-
-			String path = ((FileEditorInput) obj).getFile().getFullPath().toString();
-			URI platformUri = URI.createPlatformResourceURI(path, true);
-
-			for (Resource resource : domain.getResourceSet().getResources()) {
-				if (resource.getURI().equals(platformUri)) {
-					return true;
-				}
-			}
-
+		if (obj instanceof IEditorInput) {
+			URI otherModelUri = FileService.getInputUri((IEditorInput) obj);
+			return equalsModelUri(otherModelUri);
 		}
-		
-		if (obj instanceof Bpmn2DiagramEditorInput) {
-			return ((Bpmn2DiagramEditorInput) obj).getDiagramUri().equals(getDiagramUri());
-		}
-		
+	
 		return false;
 	}
 
+	private boolean equalsModelUri(URI otherUri) {
+		if (otherUri == null) {
+			return false;
+		}
+		
+		String modelRef = toAbsoluteRef(modelUri);
+		String otherRef = toAbsoluteRef(otherUri);
+		
+//		System.out.println("Compare <" + modelRef + ">\n" + 
+//				               "   with <" + otherRef + ">\n");
+		
+		// handle the error case that any of the uris could
+		// not be transformed into absolute refs
+		if (modelRef == null || otherRef == null) {
+			return false;
+		}
+		
+		return modelRef.equals(otherRef);
+	}
+
+	private static String toAbsoluteRef(URI uri) {
+		
+		if (uri.isFile()) {
+			return uri.toFileString();
+		}
+		
+		if (uri.isPlatformResource()) {
+			IWorkspace workspace = ResourcesPlugin.getWorkspace();
+			IWorkspaceRoot root = workspace.getRoot();
+			
+			IResource member = root.findMember(uri.toPlatformString(true));
+			if (member != null) {
+				return member.getLocation().toOSString();
+			}
+		}
+		
+		return null;
+	}
+	
 	public BPMNDiagram getBpmnDiagram() {
 		return bpmnDiagram;
 	}
@@ -120,9 +147,10 @@ public final class Bpmn2DiagramEditorInput extends DiagramEditorInput {
 	@Override
 	public void saveState(IMemento memento) {
 		super.saveState(memento);
+		
 		/**
 		 * We are storing the modelUri in the uri field of the DiagramEditorInput
 		 */
-		memento.putString(KEY_URI, this.modelUri.toString());
+		memento.putString(KEY_URI, modelUri.toString());
 	}
 }

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/wizards/FileService.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/wizards/FileService.java
@@ -51,6 +51,7 @@ import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.ui.editor.DiagramEditorInput;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IStorageEditorInput;
+import org.eclipse.ui.ide.FileStoreEditorInput;
 import org.eclipse.ui.part.FileEditorInput;
 
 public class FileService {
@@ -222,25 +223,32 @@ public class FileService {
 			URI uri = ((Bpmn2DiagramEditorInput) input).getModelUri();
 			return uri.trimFragment();
 		} else if (input instanceof FileEditorInput) {
-			IPath path =  ((FileEditorInput) input).getFile().getFullPath();
+			IPath path = ((FileEditorInput) input).getFile().getFullPath();
 			return URI.createPlatformResourceURI(path.toString(), true);
 		} else if (input instanceof IStorageEditorInput) {
 			IStorageEditorInput sei = (IStorageEditorInput) input;
 
 			try {
 				IPath path = sei.getStorage().getFullPath();
-				if (path!=null)
+				if (path!=null) {
 					return URI.createPlatformResourceURI(path.toString(), true);
-
+				}
+				
 				// the input is not a local file. Create a temp file and copy its contents
 				String name = sei.getStorage().getName();
-				InputStream istream = sei.getStorage().getContents();
+				InputStream istream;
+				
+				istream = sei.getStorage().getContents();
+	
 				File file = createTempFile(name, istream);
 				return URI.createFileURI(file.getPath());
+			} catch (CoreException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
 			}
-			catch (Exception e) {
-			}
-		}else if (input instanceof DiagramEditorInput) {
+		} else if (input instanceof FileStoreEditorInput) {
+			return URI.createURI(((FileStoreEditorInput) input).getURI().toString());
+		} else if (input instanceof DiagramEditorInput) {
 			return ((DiagramEditorInput) input).getUri();
 		}
 		return null;


### PR DESCRIPTION
This commit unifies uri handling for various resources that
may be opened by the modeler as BPMN 2.0 files.

This allows us to open any kind of BPMN 2.0 file, independent of
whether it belongs to a workspace or not.
- FileService#getInputUri() is responsible for retrieving
- Equals check for BPMN 2.0 DiagramEditorInput normalizes the inputs to
  file system absolute path
- DiagramExport exports diagrams only in Workspace mode

Closes CAM-1648
