### PR TITLE
Fix of missing layout update for Call Activity / Sub Process / ...

### DIFF
--- a/org.camunda.bpm.modeler/model/activitiExtensions.ecore
+++ b/org.camunda.bpm.modeler/model/activitiExtensions.ecore
@@ -353,6 +353,7 @@
     <eLiterals name="create"/>
     <eLiterals name="assignment" value="1"/>
     <eLiterals name="complete" value="2"/>
+    <eLiterals name="delete" value="3" literal="delete"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EEnum" name="EventType1">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">

--- a/org.camunda.bpm.modeler/p2/indigo-snapshot/p2.inf
+++ b/org.camunda.bpm.modeler/p2/indigo-snapshot/p2.inf
@@ -1,3 +1,0 @@
-instructions.configure=\
-addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/nightly/site,name:Camunda Modeler - Indigo Nightly);\
-addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/nightly/site,name:Camunda Modeler - Indigo Nightly);

--- a/org.camunda.bpm.modeler/p2/indigo/p2.inf
+++ b/org.camunda.bpm.modeler/p2/indigo/p2.inf
@@ -1,3 +1,0 @@
-instructions.configure=\
-addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/latest/site,name:Camunda Modeler - Indigo Release);\
-addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/latest/site,name:Camunda Modeler - Indigo Release);

--- a/org.camunda.bpm.modeler/p2/kepler-snapshot/p2.inf
+++ b/org.camunda.bpm.modeler/p2/kepler-snapshot/p2.inf
@@ -1,3 +1,0 @@
-instructions.configure=\
-addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/kepler/nightly/site,name:Camunda Modeler - Kepler Nightly);\
-addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/kepler/nightly/site,name:Camunda Modeler - Kepler Nightly);

--- a/org.camunda.bpm.modeler/p2/kepler/p2.inf
+++ b/org.camunda.bpm.modeler/p2/kepler/p2.inf
@@ -1,3 +1,0 @@
-instructions.configure=\
-addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/kepler/latest/site,name:Camunda Modeler - Kepler Release);\
-addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/kepler/latest/site,name:Camunda Modeler - Kepler Release);

--- a/org.camunda.bpm.modeler/p2/mars-snapshot/p2.inf
+++ b/org.camunda.bpm.modeler/p2/mars-snapshot/p2.inf
@@ -1,0 +1,3 @@
+instructions.configure=\
+addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/nightly/site,name:Camunda Modeler - Mars Nightly);\
+addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/nightly/site,name:Camunda Modeler - Mars Nightly);

--- a/org.camunda.bpm.modeler/p2/mars/p2.inf
+++ b/org.camunda.bpm.modeler/p2/mars/p2.inf
@@ -1,0 +1,3 @@
+instructions.configure=\
+addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/latest/site,name:Camunda Modeler - Mars Release);\
+addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/latest/site,name:Camunda Modeler - Mars Release);

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/core/features/DefaultBpmn2LayoutShapeFeature.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/core/features/DefaultBpmn2LayoutShapeFeature.java
@@ -9,8 +9,10 @@ import java.util.Set;
 
 import org.camunda.bpm.modeler.core.layout.util.LayoutUtil;
 import org.camunda.bpm.modeler.core.layout.util.Layouter;
+import org.camunda.bpm.modeler.core.utils.BusinessObjectUtil;
 import org.eclipse.bpmn2.BaseElement;
 import org.eclipse.bpmn2.BoundaryEvent;
+import org.eclipse.bpmn2.Group;
 import org.eclipse.bpmn2.Lane;
 import org.eclipse.bpmn2.Participant;
 import org.eclipse.bpmn2.SubProcess;
@@ -22,6 +24,8 @@ import org.eclipse.graphiti.mm.pictograms.Connection;
 import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.eclipse.graphiti.mm.pictograms.Shape;
+import org.eclipse.graphiti.services.Graphiti;
+import org.eclipse.graphiti.services.IPeService;
 
 /**
  * Default layouting implementation for all shapes (non-connections).
@@ -179,6 +183,17 @@ public class DefaultBpmn2LayoutShapeFeature extends AbstractBpmn2LayoutElementFe
 		
 		for (Connection connection : connections) {
 			layoutConnection(connection, context);
+		}
+		
+		// repairing connections is a good trigger to bring all Groups back to front
+		IPeService peService = Graphiti.getPeService();
+		List<Shape> diagramChildren = // beware of concurrent modification 
+				new ArrayList<Shape>(getDiagram().getChildren());
+		for (Shape s: diagramChildren) {
+			if (s instanceof ContainerShape && 
+					BusinessObjectUtil.getFirstBaseElement(s) instanceof Group) {
+				peService.sendToFront(s); 
+			}
 		}
 	}
 

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/core/features/DefaultBpmn2LayoutShapeFeature.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/core/features/DefaultBpmn2LayoutShapeFeature.java
@@ -62,6 +62,9 @@ public class DefaultBpmn2LayoutShapeFeature extends AbstractBpmn2LayoutElementFe
 		
 		if (isRepairConnections(context)) {
 			repairConnections(context);
+			// repairing connections is a good trigger
+			// to bring all Group shapes back to front 
+			repairGroupZOrder(context);
 		}
 		
 		return true;
@@ -183,9 +186,15 @@ public class DefaultBpmn2LayoutShapeFeature extends AbstractBpmn2LayoutElementFe
 		
 		for (Connection connection : connections) {
 			layoutConnection(connection, context);
-		}
-		
-		// repairing connections is a good trigger to bring all Groups back to front
+		}		
+	}
+	
+	/**
+	 * Repairs the Z-order of all Group shapes and brings them back to front.
+	 * 
+	 * @param context the layout context
+	 */
+	protected void repairGroupZOrder(ILayoutContext context) {
 		IPeService peService = Graphiti.getPeService();
 		List<Shape> diagramChildren = // beware of concurrent modification 
 				new ArrayList<Shape>(getDiagram().getChildren());

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/core/importer/handlers/AssociationShapeHandler.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/core/importer/handlers/AssociationShapeHandler.java
@@ -38,7 +38,7 @@ public class AssociationShapeHandler extends AbstractEdgeHandler<Association> {
 		
 		String errorFormat = "%s reference of %s is null. Edge is not visible (%s)";
 		
-		if (target == null || source.eIsProxy()) {
+		if (target == null || target.eIsProxy()) {
 			modelImport.logSilently(new ImportException(
 					String.format(errorFormat,
 						"Target",

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/runtime/engine/model/EventType.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/runtime/engine/model/EventType.java
@@ -1,8 +1,4 @@
 /**
- * <copyright>
- * </copyright>
- *
- * $Id$
  */
 package org.camunda.bpm.modeler.runtime.engine.model;
 
@@ -50,7 +46,17 @@ public enum EventType implements Enumerator {
 	 * @generated
 	 * @ordered
 	 */
-	COMPLETE(2, "complete", "complete");
+	COMPLETE(2, "complete", "complete"),
+
+	/**
+	 * The '<em><b>Delete</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #DELETE_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	DELETE(3, "delete", "delete");
 
 	/**
 	 * The '<em><b>Create</b></em>' literal value.
@@ -98,6 +104,21 @@ public enum EventType implements Enumerator {
 	public static final int COMPLETE_VALUE = 2;
 
 	/**
+	 * The '<em><b>Delete</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of '<em><b>Delete</b></em>' literal object isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @see #DELETE
+	 * @model name="delete"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int DELETE_VALUE = 3;
+
+	/**
 	 * An array of all the '<em><b>Event Type</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -108,6 +129,7 @@ public enum EventType implements Enumerator {
 			CREATE,
 			ASSIGNMENT,
 			COMPLETE,
+			DELETE,
 		};
 
 	/**
@@ -161,6 +183,7 @@ public enum EventType implements Enumerator {
 			case CREATE_VALUE: return CREATE;
 			case ASSIGNMENT_VALUE: return ASSIGNMENT;
 			case COMPLETE_VALUE: return COMPLETE;
+			case DELETE_VALUE: return DELETE;
 		}
 		return null;
 	}

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/AbstractExpandableActivityFeatureContainer.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/AbstractExpandableActivityFeatureContainer.java
@@ -23,14 +23,34 @@ import org.eclipse.graphiti.features.IDirectEditingFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.ILayoutFeature;
 import org.eclipse.graphiti.features.IResizeShapeFeature;
+import org.eclipse.graphiti.features.context.IDirectEditingContext;
 import org.eclipse.graphiti.features.context.IUpdateContext;
 import org.eclipse.graphiti.features.custom.ICustomFeature;
+import org.eclipse.graphiti.mm.pictograms.PictogramElement;
+import org.eclipse.graphiti.mm.pictograms.Shape;
 
 public abstract class AbstractExpandableActivityFeatureContainer extends AbstractActivityFeatureContainer {
 
 	@Override
 	public IDirectEditingFeature getDirectEditingFeature(IFeatureProvider fp) {
-		return new DirectEditActivityFeature(fp);
+		return new DirectEditActivityFeature(fp) {
+			@Override
+			public void setValue(String value, IDirectEditingContext context) {
+				// get old value for fix below
+				Object businessObject = getBusinessObject(context);
+				String oldValue = getNameValue(businessObject);
+
+				// update the value
+				setNameValue(businessObject, value);
+				PictogramElement e = context.getPictogramElement();
+				updatePictogramElement(((Shape) e).getContainer());
+
+				// fix for missing layout update when editing initial value
+				if (oldValue == null) {
+					layoutPictogramElement(e);
+				}
+			}
+		};
 	}
 
 	@Override

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/AbstractExpandableActivityFeatureContainer.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/AbstractExpandableActivityFeatureContainer.java
@@ -23,26 +23,14 @@ import org.eclipse.graphiti.features.IDirectEditingFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.ILayoutFeature;
 import org.eclipse.graphiti.features.IResizeShapeFeature;
-import org.eclipse.graphiti.features.context.IDirectEditingContext;
 import org.eclipse.graphiti.features.context.IUpdateContext;
 import org.eclipse.graphiti.features.custom.ICustomFeature;
-import org.eclipse.graphiti.mm.pictograms.PictogramElement;
-import org.eclipse.graphiti.mm.pictograms.Shape;
 
 public abstract class AbstractExpandableActivityFeatureContainer extends AbstractActivityFeatureContainer {
 
 	@Override
 	public IDirectEditingFeature getDirectEditingFeature(IFeatureProvider fp) {
-		return new DirectEditActivityFeature(fp) {
-			@Override
-			public void setValue(String value, IDirectEditingContext context) {
-				setNameValue(getBusinessObject(context), value);
-				PictogramElement e = context.getPictogramElement();
-				updatePictogramElement(((Shape) e).getContainer());
-				// fix missing layout update when editing value
-				layoutPictogramElement(e);
-			}
-		};
+		return new DirectEditActivityFeature(fp);
 	}
 
 	@Override

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/AbstractExpandableActivityFeatureContainer.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/AbstractExpandableActivityFeatureContainer.java
@@ -36,19 +36,11 @@ public abstract class AbstractExpandableActivityFeatureContainer extends Abstrac
 		return new DirectEditActivityFeature(fp) {
 			@Override
 			public void setValue(String value, IDirectEditingContext context) {
-				// get old value for fix below
-				Object businessObject = getBusinessObject(context);
-				String oldValue = getNameValue(businessObject);
-
-				// update the value
-				setNameValue(businessObject, value);
+				setNameValue(getBusinessObject(context), value);
 				PictogramElement e = context.getPictogramElement();
 				updatePictogramElement(((Shape) e).getContainer());
-
-				// fix for missing layout update when editing initial value
-				if (oldValue == null) {
-					layoutPictogramElement(e);
-				}
+				// fix missing layout update when editing value
+				layoutPictogramElement(e);
 			}
 		};
 	}

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/AddExpandableActivityFeature.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/AddExpandableActivityFeature.java
@@ -20,7 +20,7 @@ import org.eclipse.bpmn2.Activity;
 import org.eclipse.graphiti.datatypes.IRectangle;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.context.IAddContext;
-import org.eclipse.graphiti.mm.algorithms.Text;
+import org.eclipse.graphiti.mm.algorithms.MultiText;
 import org.eclipse.graphiti.mm.algorithms.styles.Orientation;
 import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
@@ -45,14 +45,13 @@ public class AddExpandableActivityFeature<T extends Activity>
 
 		T activity = getBusinessObject(context);
 
-		int width = newShapeBounds.getWidth();
-
 		Shape textShape = peService.createShape(newShape, false);
-		Text text = gaService.createDefaultText(getDiagram(), textShape, activity.getName());
-		gaService.setLocationAndSize(text, 5, 5, width - 10, 15);
+		MultiText text = gaService.createDefaultMultiText(getDiagram(), textShape, activity.getName());
+		gaService.setLocationAndSize(text, 5, 5, newShapeBounds.getWidth() - 10, newShapeBounds.getHeight() - 10);
+
 		StyleUtil.applyStyle(text, activity);
 		text.setHorizontalAlignment(Orientation.ALIGNMENT_CENTER);
-		text.setVerticalAlignment(Orientation.ALIGNMENT_CENTER);
+		text.setVerticalAlignment(Orientation.ALIGNMENT_TOP);
 		link(textShape, activity);
 	}
 	

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/LayoutExpandableActivityFeature.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/LayoutExpandableActivityFeature.java
@@ -13,10 +13,9 @@
 package org.camunda.bpm.modeler.ui.features.activity.subprocess;
 
 import org.camunda.bpm.modeler.core.features.activity.LayoutActivityFeature;
-import org.camunda.bpm.modeler.core.utils.GraphicsUtil;
 import org.eclipse.graphiti.datatypes.IRectangle;
 import org.eclipse.graphiti.features.IFeatureProvider;
-import org.eclipse.graphiti.mm.algorithms.Text;
+import org.eclipse.graphiti.mm.algorithms.AbstractText;
 import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.Shape;
 import org.eclipse.graphiti.services.Graphiti;
@@ -30,13 +29,8 @@ public class LayoutExpandableActivityFeature extends LayoutActivityFeature {
 	@Override
 	protected void layoutLabel(ContainerShape container, Shape labelShape, IRectangle bounds) {
 
-		Text text = (Text) labelShape.getGraphicsAlgorithm();
+		AbstractText text = (AbstractText) labelShape.getGraphicsAlgorithm();
 
-		int padding = 5;
-
-		int width = bounds.getWidth() - padding;
-		int height = Math.min(GraphicsUtil.getLabelHeight(text), bounds.getHeight() - padding);
-
-		Graphiti.getGaService().setLocationAndSize(text, padding, padding, width, height);
+		Graphiti.getGaService().setLocationAndSize(text, 5, 5, bounds.getWidth() - 10, bounds.getHeight() - 10);
 	}
 }

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/LayoutExpandableActivityFeature.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/LayoutExpandableActivityFeature.java
@@ -12,12 +12,7 @@
  ******************************************************************************/
 package org.camunda.bpm.modeler.ui.features.activity.subprocess;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.camunda.bpm.modeler.core.features.activity.LayoutActivityFeature;
-import org.camunda.bpm.modeler.core.utils.BusinessObjectUtil;
-import org.eclipse.bpmn2.Group;
 import org.eclipse.graphiti.datatypes.IRectangle;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.context.ILayoutContext;
@@ -25,7 +20,6 @@ import org.eclipse.graphiti.mm.algorithms.AbstractText;
 import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.Shape;
 import org.eclipse.graphiti.services.Graphiti;
-import org.eclipse.graphiti.services.IPeService;
 
 public class LayoutExpandableActivityFeature extends LayoutActivityFeature {
 
@@ -46,15 +40,7 @@ public class LayoutExpandableActivityFeature extends LayoutActivityFeature {
 		super.postLayoutShapeAndChildren(shape, context);
 
 		// bring all Groups, if any, back to front
-		IPeService peService = Graphiti.getPeService();
-		List<Shape> diagramChildren = // beware of concurrent modification 
-				new ArrayList<Shape>(getDiagram().getChildren());
-		for (Shape s: diagramChildren) {
-			if (s instanceof ContainerShape && 
-					BusinessObjectUtil.getFirstBaseElement(s) instanceof Group) {
-				peService.sendToFront(s); 
-			}
-		}
+		repairGroupZOrder(context);
 	}
 	
 	

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/LayoutExpandableActivityFeature.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/LayoutExpandableActivityFeature.java
@@ -12,13 +12,20 @@
  ******************************************************************************/
 package org.camunda.bpm.modeler.ui.features.activity.subprocess;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.camunda.bpm.modeler.core.features.activity.LayoutActivityFeature;
+import org.camunda.bpm.modeler.core.utils.BusinessObjectUtil;
+import org.eclipse.bpmn2.Group;
 import org.eclipse.graphiti.datatypes.IRectangle;
 import org.eclipse.graphiti.features.IFeatureProvider;
+import org.eclipse.graphiti.features.context.ILayoutContext;
 import org.eclipse.graphiti.mm.algorithms.AbstractText;
 import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.Shape;
 import org.eclipse.graphiti.services.Graphiti;
+import org.eclipse.graphiti.services.IPeService;
 
 public class LayoutExpandableActivityFeature extends LayoutActivityFeature {
 
@@ -33,4 +40,22 @@ public class LayoutExpandableActivityFeature extends LayoutActivityFeature {
 
 		Graphiti.getGaService().setLocationAndSize(text, 5, 5, bounds.getWidth() - 10, bounds.getHeight() - 10);
 	}
+
+	@Override
+	protected void postLayoutShapeAndChildren(ContainerShape shape, ILayoutContext context) {
+		super.postLayoutShapeAndChildren(shape, context);
+
+		// bring all Groups, if any, back to front
+		IPeService peService = Graphiti.getPeService();
+		List<Shape> diagramChildren = // beware of concurrent modification 
+				new ArrayList<Shape>(getDiagram().getChildren());
+		for (Shape s: diagramChildren) {
+			if (s instanceof ContainerShape && 
+					BusinessObjectUtil.getFirstBaseElement(s) instanceof Group) {
+				peService.sendToFront(s); 
+			}
+		}
+	}
+	
+	
 }

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/ResizeExpandableActivityFeature.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/features/activity/subprocess/ResizeExpandableActivityFeature.java
@@ -17,7 +17,12 @@ import org.camunda.bpm.modeler.ui.features.activity.ResizeActivityFeature;
 import org.eclipse.bpmn2.di.BPMNShape;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.context.IResizeShapeContext;
+import org.eclipse.graphiti.mm.algorithms.GraphicsAlgorithm;
+import org.eclipse.graphiti.mm.algorithms.MultiText;
 import org.eclipse.graphiti.mm.pictograms.ContainerShape;
+import org.eclipse.graphiti.mm.pictograms.PictogramElement;
+import org.eclipse.graphiti.services.Graphiti;
+import org.eclipse.graphiti.services.IGaService;
 
 /**
  * Expandable activities resize feature.
@@ -42,4 +47,25 @@ public class ResizeExpandableActivityFeature extends ResizeActivityFeature {
 		
 		return super.canResizeShape(context);
 	}
+
+
+	@Override
+	protected void postResize(IResizeShapeContext context) {
+		super.postResize(context);
+
+		IGaService gaService = Graphiti.getGaService();
+
+		ContainerShape containerShape = (ContainerShape) context.getShape();
+		BPMNShape bpmnShape = BusinessObjectUtil.getFirstElementOfType(containerShape, BPMNShape.class);
+
+		// resize the MultiText element (holding the name of the element) appropriately
+		for (PictogramElement pe : containerShape.getChildren()) {
+			GraphicsAlgorithm ga = pe.getGraphicsAlgorithm();
+			if (ga instanceof MultiText) {
+				gaService.setLocationAndSize(ga, 5, 5, (int) bpmnShape.getBounds().getWidth() - 10, (int) bpmnShape.getBounds().getHeight() - 10);
+				break;
+			}
+		}
+	}
+
 }

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/property/tabs/dialog/TaskListenerDialog.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/property/tabs/dialog/TaskListenerDialog.java
@@ -37,6 +37,7 @@ public class TaskListenerDialog extends ListenerDialog<TaskListenerType> {
 		dropDown.add(EventType.CREATE.getName());
 		dropDown.add(EventType.ASSIGNMENT.getName());
 		dropDown.add(EventType.COMPLETE.getName());
+		dropDown.add(EventType.DELETE.getName());
 		
 		ValidatingStringComboBinding comboBinding = new ValidatingStringComboBinding(listener, TASK_LISTENER_EVENT_FEATURE, dropDown) {
 			


### PR DESCRIPTION
I'm aware that you plan to use bpmn.io as favorite modelling tool for developers. And I'm already curious about it! Just in case the current Eclipse BPMN Modeler plugin will live for some more months - here is another fix for an annoying error.

When editing the name of a Call Activity, Sub Process, etc. (see subclasses of AbstractExpandableActivityFeatureContainer) there is a missing layout update: 

To reproduce the error create a new CallActivity within a process and edit its name directly within the diagram. Sadly the new name won't get rendered, the value has been set but it's somehow not visible. The same happens in case you change a name and insert a line break. You will have to move/resize the CallActivity or do something else to trigger a refresh in case you want to see the edited name within the diagram. 

The layout update will now be triggered explicitly after changing the value.

Cheers
Gunnar