### PR TITLE
Fixed NullPointer during import in AssociationShapeHandler

### DIFF
--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/core/importer/handlers/AssociationShapeHandler.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/core/importer/handlers/AssociationShapeHandler.java
@@ -38,7 +38,7 @@ public class AssociationShapeHandler extends AbstractEdgeHandler<Association> {
 		
 		String errorFormat = "%s reference of %s is null. Edge is not visible (%s)";
 		
-		if (target == null || source.eIsProxy()) {
+		if (target == null || target.eIsProxy()) {
 			modelImport.logSilently(new ImportException(
 					String.format(errorFormat,
 						"Target",


### PR DESCRIPTION
The fixed NullPointer is somehow related to CAM-4041 - even if source and target reference are still not supported. Importing a BPM model from Signavio which includes data objects has thrown the NullPointer - and the cause has been obvious.