### PR TITLE
Mars specific update sites

### DIFF
--- a/org.camunda.bpm.modeler/p2/indigo-snapshot/p2.inf
+++ b/org.camunda.bpm.modeler/p2/indigo-snapshot/p2.inf
@@ -1,3 +1,0 @@
-instructions.configure=\
-addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/nightly/site,name:Camunda Modeler - Indigo Nightly);\
-addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/nightly/site,name:Camunda Modeler - Indigo Nightly);

--- a/org.camunda.bpm.modeler/p2/indigo/p2.inf
+++ b/org.camunda.bpm.modeler/p2/indigo/p2.inf
@@ -1,3 +1,0 @@
-instructions.configure=\
-addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/latest/site,name:Camunda Modeler - Indigo Release);\
-addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/latest/site,name:Camunda Modeler - Indigo Release);

--- a/org.camunda.bpm.modeler/p2/kepler-snapshot/p2.inf
+++ b/org.camunda.bpm.modeler/p2/kepler-snapshot/p2.inf
@@ -1,3 +1,0 @@
-instructions.configure=\
-addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/kepler/nightly/site,name:Camunda Modeler - Kepler Nightly);\
-addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/kepler/nightly/site,name:Camunda Modeler - Kepler Nightly);

--- a/org.camunda.bpm.modeler/p2/kepler/p2.inf
+++ b/org.camunda.bpm.modeler/p2/kepler/p2.inf
@@ -1,3 +1,0 @@
-instructions.configure=\
-addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/kepler/latest/site,name:Camunda Modeler - Kepler Release);\
-addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/kepler/latest/site,name:Camunda Modeler - Kepler Release);

--- a/org.camunda.bpm.modeler/p2/mars-snapshot/p2.inf
+++ b/org.camunda.bpm.modeler/p2/mars-snapshot/p2.inf
@@ -1,3 +1,3 @@
 instructions.configure=\
-addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/nightly/site,name:Camunda Modeler - Mars Nightly);\
-addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/nightly/site,name:Camunda Modeler - Mars Nightly);
+addRepository(type:0,location:http${#58}//camunda.org/release/camunda-eclipse-plugin/update-sites/mars/nightly/site,name:Camunda Modeler - Mars Nightly);\
+addRepository(type:1,location:http${#58}//camunda.org/release/camunda-eclipse-plugin/update-sites/mars/nightly/site,name:Camunda Modeler - Mars Nightly);

--- a/org.camunda.bpm.modeler/p2/mars-snapshot/p2.inf
+++ b/org.camunda.bpm.modeler/p2/mars-snapshot/p2.inf
@@ -1,0 +1,3 @@
+instructions.configure=\
+addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/nightly/site,name:Camunda Modeler - Mars Nightly);\
+addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/nightly/site,name:Camunda Modeler - Mars Nightly);

--- a/org.camunda.bpm.modeler/p2/mars/p2.inf
+++ b/org.camunda.bpm.modeler/p2/mars/p2.inf
@@ -1,0 +1,3 @@
+instructions.configure=\
+addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/latest/site,name:Camunda Modeler - Mars Release);\
+addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/latest/site,name:Camunda Modeler - Mars Release);

--- a/org.camunda.bpm.modeler/p2/mars/p2.inf
+++ b/org.camunda.bpm.modeler/p2/mars/p2.inf
@@ -1,3 +1,3 @@
 instructions.configure=\
-addRepository(type:0,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/latest/site,name:Camunda Modeler - Mars Release);\
-addRepository(type:1,location:http${#58}//www.camunda.org/release/camunda-modeler/update-sites/mars/latest/site,name:Camunda Modeler - Mars Release);
+addRepository(type:0,location:http${#58}//camunda.org/release/camunda-eclipse-plugin/update-sites/mars/latest/site,name:Camunda Modeler - Mars Release);\
+addRepository(type:1,location:http${#58}//camunda.org/release/camunda-eclipse-plugin/update-sites/mars/latest/site,name:Camunda Modeler - Mars Release);


### PR DESCRIPTION
When installing a the Mars compatible Eclipse plugin you do not want to have Indigo/Kepler Update sites - this might destroy your installation in case e.g. a new Kepler Update of the Eclipse plugin has been published.
